### PR TITLE
fix(install): :ambulance: MikTeX force remove fails

### DIFF
--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -150,7 +150,7 @@ exit
     )
 
     for /f "usebackq delims=" %%i in (`"where miktex"`) do (
-        rmdir /s /q "%%~pi\..\..\..\"
+        rmdir /s /q "%%~fi\..\..\..\"
     )
     cd "%cwd_setup%"
     goto:EOF


### PR DESCRIPTION
Merged from https://github.com/hampoelz/LaTeX-Template/tree/main

(picked commits: 386e660)